### PR TITLE
HW4 obstacles_env render fix 

### DIFF
--- a/hw4/cs285/envs/obstacles/obstacles_env.py
+++ b/hw4/cs285/envs/obstacles/obstacles_env.py
@@ -72,6 +72,7 @@ class Obstacles(gym.Env):
 
         #clear
         self.counter = 0
+        self.plt.figure(self.fig.number)
         self.plt.clf()
 
         #return


### PR DESCRIPTION
I seemed to have an issue where rendering the evaluation paths would simply output copies of the last frame of the training paths. It seemed that the reference to the current active matplotlib figure was lost at some point, and thus the canvas was not reset from do_reset(). This one line fixed the problem for me.