### PR TITLE
Update run_hw1.ipynb

### DIFF
--- a/hw1/cs285/scripts/run_hw1.ipynb
+++ b/hw1/cs285/scripts/run_hw1.ipynb
@@ -123,10 +123,9 @@
     "MJC_PATH = '{}/mujoco'.format(SYM_PATH)\n",
     "%mkdir $MJC_PATH\n",
     "%cd $MJC_PATH\n",
-    "!wget -q https://www.roboti.us/download/mujoco200_linux.zip\n",
-    "!unzip -q mujoco200_linux.zip\n",
-    "%mv mujoco200_linux mujoco200\n",
-    "%rm mujoco200_linux.zip"
+    "!wget -q https://mujoco.org/download/mujoco210-linux-x86_64.tar.gz\n",
+    "!tar -xvf mujoco210-linux-x86_64.tar.gz\n",
+    "%rm mujoco210-linux-x86_64.tar.gz"
    ]
   },
   {
@@ -144,13 +143,13 @@
     "\n",
     "import os\n",
     "\n",
-    "os.environ['LD_LIBRARY_PATH'] += ':{}/mujoco200/bin'.format(MJC_PATH)\n",
-    "os.environ['MUJOCO_PY_MUJOCO_PATH'] = '{}/mujoco200'.format(MJC_PATH)\n",
+    "os.environ['LD_LIBRARY_PATH'] += ':{}/mujoco210/bin'.format(MJC_PATH)\n",
+    "os.environ['MUJOCO_PY_MUJOCO_PATH'] = '{}/mujoco210'.format(MJC_PATH)\n",
     "os.environ['MUJOCO_PY_MJKEY_PATH'] = '{}/mjkey.txt'.format(MJC_PATH)\n",
     "\n",
     "## installation on colab does not find *.so files\n",
     "## in LD_LIBRARY_PATH, copy over manually instead\n",
-    "!cp $MJC_PATH/mujoco200/bin/*.so /usr/lib/x86_64-linux-gnu/"
+    "!cp $MJC_PATH/mujoco210/bin/*.so /usr/lib/x86_64-linux-gnu/"
    ]
   },
   {


### PR DESCRIPTION
Current `mujoco_py` supports mujoco 2.1.0, not 2.0.0.
Workaround is #4 
So it needs to change file paths to modify.